### PR TITLE
Fix shebang

### DIFF
--- a/session_1/notebooks/introduction_python.ipynb
+++ b/session_1/notebooks/introduction_python.ipynb
@@ -189,7 +189,7 @@
     "\n",
     "Shebang line: \n",
     "\n",
-    "    #!/usr/bin/env/python \n",
+    "    #!/usr/bin/env python \n",
     "    \n",
     "or path to your python binary\n",
     "\n",


### PR DESCRIPTION
Hi Nico!

I think instead of `/usr/bin/env/python`, it must be `/usr/bin/env python` instead.

Cheers
Bruno
